### PR TITLE
INPL 117 - Exibir spinner enquanto os dados dos gráficos estão sendo carregados

### DIFF
--- a/src/app/features/strategic-projects/data-chart/accumulated-investment/accumulatedInvestment.component.html
+++ b/src/app/features/strategic-projects/data-chart/accumulated-investment/accumulatedInvestment.component.html
@@ -2,6 +2,7 @@
   [cardTitle]="'Investimento Acumulado'"
   [tableContent]="flipTableContent"
   [backCardHeight]="290"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/accumulated-investment/accumulatedInvestment.component.ts
+++ b/src/app/features/strategic-projects/data-chart/accumulated-investment/accumulatedInvestment.component.ts
@@ -6,6 +6,7 @@ import { StrategicProjectsService } from '../../../../core/service/strategic-pro
 import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
 import { UtilitiesService } from '../../../../core/service/utilities.service';
+import { RequestStatus } from '../../strategicProjects.component';
 
 
 @Component({
@@ -31,6 +32,8 @@ export class AccumulatedInvestmentComponent implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -44,6 +47,7 @@ export class AccumulatedInvestmentComponent implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
 
@@ -58,9 +62,12 @@ export class AccumulatedInvestmentComponent implements OnChanges {
         }));
 
         this.assembleFlipTableContent(this.accumulatedInvestmentData);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados do investimento acumulado:', error);
+        this.requestStatus = RequestStatus.ERROR;
       });
 
     this.chartColors = ['#42726F', '#00A261'];

--- a/src/app/features/strategic-projects/data-chart/critical-milestones-for-performance/criticalMilestonesForPerformace.component.ts
+++ b/src/app/features/strategic-projects/data-chart/critical-milestones-for-performance/criticalMilestonesForPerformace.component.ts
@@ -5,6 +5,7 @@ import { IStrategicProjectDeliveries, IStrategicProjectDeliveriesShow } from '..
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-critical-milestones-for-performance',
@@ -31,6 +32,8 @@ export class CriticalMilestonesForPerformanceComponent  implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -43,6 +46,7 @@ export class CriticalMilestonesForPerformanceComponent  implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
     this.performanceShow = [];
@@ -81,10 +85,13 @@ export class CriticalMilestonesForPerformanceComponent  implements OnChanges {
         this.hasData = this.chartData.length > 0;
 
         this.assembleFlipTableContent(data);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas por status:', error);
         this.hasData = false;
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/data-chart/critical-milestones-for-performance/criticalMilestonesForPerformance.component.html
+++ b/src/app/features/strategic-projects/data-chart/critical-milestones-for-performance/criticalMilestonesForPerformance.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [cardTitle]="'Marcos Críticos por Desempenho'"
   [tableContent]="flipTableContent"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-performance/deliveriesByPerformace.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-performance/deliveriesByPerformace.component.ts
@@ -5,6 +5,7 @@ import { IStrategicProjectDeliveries, IStrategicProjectDeliveriesShow } from '..
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-deliveries-by-performace',
@@ -29,6 +30,8 @@ export class DeliveriesByPerformaceComponent implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -41,6 +44,7 @@ export class DeliveriesByPerformaceComponent implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
     this.performanceShow = [];
@@ -78,9 +82,12 @@ export class DeliveriesByPerformaceComponent implements OnChanges {
         this.chartColors = this.performanceShow.map(val => val.corStatus);
 
         this.assembleFlipTableContent(data);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas por desempenho:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-performance/deliveriesByPerformance.component.html
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-performance/deliveriesByPerformance.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [cardTitle]="'Entregas por Desempenho'"
   [tableContent]="flipTableContent"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.html
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [tableContent]="flipTableContent"
   [backCardHeight]="290"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.ts
@@ -6,6 +6,7 @@ import { IStrategicProjectDeliveriesBySelected } from '../../../../core/interfac
 import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { NbSelectModule } from '@nebular/theme';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-deliveries-by-selected',
@@ -30,6 +31,8 @@ export class DeliveriesBySelectedComponent implements OnChanges {
   deliveriesSelectedOption: string = 'Área Temática';
 
   flipTableContent: FlipTableContent;
+
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
 
   constructor(
     private strategicProjectsService: StrategicProjectsService,
@@ -70,49 +73,65 @@ export class DeliveriesBySelectedComponent implements OnChanges {
   };
 
   loadDeliveriesByArea(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getDeliveriesByArea(cleanedFilter).subscribe(
       (data: IStrategicProjectDeliveriesBySelected[]) => {
         this.deliveriesData = data;
         this.formatDeliveriesChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das áreas de entrega:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
   
   loadDeliveriesByProgram(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getDeliveriesByProgram(cleanedFilter).subscribe(
       (data: IStrategicProjectDeliveriesBySelected[]) => {
         this.deliveriesData = data;
         this.formatDeliveriesChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos programas de entrega:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
   
   loadDeliveriesByCrossProgramAt(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getDeliveriesByProgramAt(cleanedFilter).subscribe(
       (data: IStrategicProjectDeliveriesBySelected[]) => {
         this.deliveriesData = data;
         this.formatDeliveriesChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos programas transversais de entrega:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
   
   loadDeliveriesByProject(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getDeliveriesByProject(cleanedFilter).subscribe(
       (data: IStrategicProjectDeliveriesBySelected[]) => {
         this.deliveriesData = data;
         this.formatDeliveriesChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos projetos de entrega:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.html
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [cardTitle]="'Entregas por Status'"
   [tableContent]="flipTableContent"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
@@ -5,6 +5,7 @@ import { StrategicProjectsService } from '../../../../core/service/strategic-pro
 import { IStrategicProjectDeliveries, IStrategicProjectDeliveriesShow } from '../../../../core/interfaces/strategic-project.interface';
 import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-deliveries-by-status',
@@ -29,6 +30,8 @@ export class DeliveriesByStatusComponent implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -41,6 +44,8 @@ export class DeliveriesByStatusComponent implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
+
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
     this.statusShow = [];
@@ -78,9 +83,12 @@ export class DeliveriesByStatusComponent implements OnChanges {
         this.chartColors = this.statusShow.map(val => val.corStatus);
 
         this.assembleFlipTableContent(data);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas por status:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-type/deliveriesByType.component.html
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-type/deliveriesByType.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [cardTitle]="'Entregas por Tipo'"
   [tableContent]="flipTableContent"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-type/deliveriesByType.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-type/deliveriesByType.component.ts
@@ -5,6 +5,7 @@ import { IStrategicProjectDeliveries, IStrategicProjectDeliveriesShow } from '..
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-deliveries-by-type',
@@ -29,6 +30,8 @@ export class DeliveriesByTypeComponent implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -41,6 +44,7 @@ export class DeliveriesByTypeComponent implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
     this.typeShow = [];
@@ -75,9 +79,12 @@ export class DeliveriesByTypeComponent implements OnChanges {
         });
 
         this.assembleFlipTableContent(data);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas por tipo:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
     

--- a/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.html
+++ b/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [tableContent]="flipTableContent"
   [backCardHeight]="290"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.ts
+++ b/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.ts
@@ -7,6 +7,7 @@ import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } fr
 import { NbSelectModule } from '@nebular/theme';
 import { ExportDataService } from '../../../../core/service/export-data';
 import { UtilitiesService } from '../../../../core/service/utilities.service';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-investment-by-selected',
@@ -31,6 +32,8 @@ export class InvestmentBySelectedComponent implements OnChanges {
   chartColors: any;
 
   investmentData: IStrategicProjectInvestmentSelected[];
+
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
 
   constructor(
     private strategicProjectsService: StrategicProjectsService,
@@ -76,61 +79,81 @@ export class InvestmentBySelectedComponent implements OnChanges {
   }
 
   loadInvestmentByArea(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getInvestmentByArea(cleanedFilter).subscribe(
       (data: IStrategicProjectInvestmentSelected[]) => {
         this.investmentData = data;
         this.formatChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das áreas temáticas:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
 
   loadInvestmentByProgram(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getInvestmentByProgram(cleanedFilter).subscribe(
       (data: IStrategicProjectInvestmentSelected[]) => {
         this.investmentData = data;
         this.formatChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos programas:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
 
   loadInvestmentByCrossProgramAt(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getInvestmentByProgramAt(cleanedFilter).subscribe(
       (data: IStrategicProjectInvestmentSelected[]) => {
         this.investmentData = data;
         this.formatChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos programas transversais:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
 
   loadInvestmentByProject(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getInvestmentByProject(cleanedFilter).subscribe(
       (data: IStrategicProjectInvestmentSelected[]) => {
         this.investmentData = data;
         this.formatChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos projetos:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }
 
   loadInvestmentByDelivery(cleanedFilter: IStrategicProjectFilterValuesDto): void {
+    this.requestStatus = RequestStatus.LOADING;
+
     this.strategicProjectsService.getInvestmentByDelivery(cleanedFilter).subscribe(
       (data: IStrategicProjectInvestmentSelected[]) => {
         this.investmentData = data;
         this.formatChartData();
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/data-chart/projects-by-status/projectsByStatus.component.html
+++ b/src/app/features/strategic-projects/data-chart/projects-by-status/projectsByStatus.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [cardTitle]="'Projetos por Status'"
   [tableContent]="flipTableContent"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/projects-by-status/projectsByStatus.component.ts
+++ b/src/app/features/strategic-projects/data-chart/projects-by-status/projectsByStatus.component.ts
@@ -5,6 +5,7 @@ import { IStrategicProjectDeliveries, IStrategicProjectDeliveriesShow } from '..
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-projects-by-status',
@@ -29,6 +30,8 @@ export class ProjectsByStatusComponent implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -41,6 +44,7 @@ export class ProjectsByStatusComponent implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
     this.statusShow = [];
@@ -78,9 +82,12 @@ export class ProjectsByStatusComponent implements OnChanges {
         this.chartColors = this.statusShow.map(val => val.corStatus);
 
         this.assembleFlipTableContent(data);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas por status:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/data-chart/risks-by-classification/risksByClassification.component.html
+++ b/src/app/features/strategic-projects/data-chart/risks-by-classification/risksByClassification.component.html
@@ -1,6 +1,7 @@
 <ngx-flip-table
   [cardTitle]="'Riscos por Importância'"
   [tableContent]="flipTableContent"
+  [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
 >

--- a/src/app/features/strategic-projects/data-chart/risks-by-classification/risksByClassification.component.ts
+++ b/src/app/features/strategic-projects/data-chart/risks-by-classification/risksByClassification.component.ts
@@ -5,6 +5,7 @@ import { IStrategicProjectDeliveriesShow, IStrategicProjectRisksByClassification
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { ExportDataService } from '../../../../core/service/export-data';
+import { RequestStatus } from '../../strategicProjects.component';
 
 @Component({
   selector: 'ngx-risks-by-classification',
@@ -29,6 +30,8 @@ export class RisksByClassificationComponent implements OnChanges {
 
   flipTableContent: FlipTableContent;
 
+  requestStatus: RequestStatus = RequestStatus.EMPTY;
+
   constructor(
     private strategicProjectsService: StrategicProjectsService,
     private exportDataService: ExportDataService,
@@ -41,6 +44,7 @@ export class RisksByClassificationComponent implements OnChanges {
   }
 
   loadData() {
+    this.requestStatus = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.filter);
     this.chartColors = [];
     this.riskShow = [];
@@ -78,9 +82,12 @@ export class RisksByClassificationComponent implements OnChanges {
         this.chartColors = this.riskShow.map(val => val.corStatus);
 
         this.assembleFlipTableContent(data);
+
+        this.requestStatus = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os dados dos riscos por classificação:', error);
+        this.requestStatus = RequestStatus.ERROR;
       }
     );
   }

--- a/src/app/features/strategic-projects/flip-table-model/flip-table.component.html
+++ b/src/app/features/strategic-projects/flip-table-model/flip-table.component.html
@@ -1,4 +1,4 @@
-<nb-card class="outer-card m-0">
+<nb-card class="outer-card m-0" [nbSpinner]="loadingStatus === 'Loading'" [nbSpinnerStatus]="'success'">
   <nb-card-header class="card-header d-flex justify-content-between align-items-start p-2 px-3">
     <ng-container *ngIf="cardTitle else customHeader">
       <span class="card-title text-truncate w-50 m-0">{{ cardTitle }}</span>

--- a/src/app/features/strategic-projects/flip-table-model/flip-table.component.ts
+++ b/src/app/features/strategic-projects/flip-table-model/flip-table.component.ts
@@ -1,7 +1,8 @@
 import { NgClass, NgFor, NgIf } from "@angular/common";
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from "@angular/core";
-import { NbCardModule, NbColumnsService, NbFormFieldModule, NbIconModule, NbInputModule, NbSortDirection, NbSortRequest, NbTooltipModule, NbTreeGridModule } from "@nebular/theme";
+import { NbCardModule, NbColumnsService, NbFormFieldModule, NbIconModule, NbInputModule, NbSortDirection, NbSortRequest, NbSpinnerModule, NbTooltipModule, NbTreeGridModule } from "@nebular/theme";
 import { TextTruncatePipe } from "../../../@theme/pipes/text-truncate.pipe";
+import { RequestStatus } from "../strategicProjects.component";
 
 export interface TreeNode {
   data: Array<{
@@ -54,6 +55,7 @@ export interface FlipTableContent {
     NbTreeGridModule,
     NbTooltipModule,
     TextTruncatePipe,
+    NbSpinnerModule,
   ]
 })
 export class FlipTableComponent implements OnChanges {
@@ -62,6 +64,8 @@ export class FlipTableComponent implements OnChanges {
   @Input() tableContent: FlipTableContent;
 
   @Input() backCardHeight: number = 150;
+
+  @Input() loadingStatus: RequestStatus = RequestStatus.LOADING;
 
   @Output() executeSearch = new EventEmitter<string>();
 

--- a/src/app/features/strategic-projects/strategicProjects.component.html
+++ b/src/app/features/strategic-projects/strategicProjects.component.html
@@ -274,7 +274,7 @@
           <div class="card-content">
             <ng-container *ngIf="requestStatus.totals === 'Loading' else programasContent">
               <div class="d-flex justify-content-center align-items-center w-100">
-                <div class="spinner-border text-warning" role="status">
+                <div class="spinner-border qt-programas" role="status">
                   <span class="sr-only">Carregando...</span>
                 </div>
               </div>
@@ -299,7 +299,7 @@
           <div class="card-content">
             <ng-container *ngIf="requestStatus.totals === 'Loading' else projetosContent">
               <div class="d-flex justify-content-center align-items-center w-100">
-                <div class="spinner-border text-warning" role="status">
+                <div class="spinner-border qt-projetos" role="status">
                   <span class="sr-only">Carregando...</span>
                 </div>
               </div>
@@ -324,7 +324,7 @@
           <div class="card-content">
             <ng-container *ngIf="requestStatus.totals === 'Loading' else entregasContent">
               <div class="d-flex justify-content-center align-items-center w-100">
-                <div class="spinner-border text-warning" role="status">
+                <div class="spinner-border total-entregas" role="status">
                   <span class="sr-only">Carregando...</span>
                 </div>
               </div>
@@ -349,7 +349,7 @@
           <div class="card-content">
             <ng-container *ngIf="requestStatus.totals === 'Loading' else previstoContent">
               <div class="d-flex justify-content-center align-items-center w-100">
-                <div class="spinner-border text-warning" role="status">
+                <div class="spinner-border total-previsto" role="status">
                   <span class="sr-only">Carregando...</span>
                 </div>
               </div>
@@ -382,7 +382,7 @@
           <div class="card-content">
             <ng-container *ngIf="requestStatus.totals === 'Loading' else realizadoContent">
               <div class="d-flex justify-content-center align-items-center w-100">
-                <div class="spinner-border text-warning" role="status">
+                <div class="spinner-border total-realizado" role="status">
                   <span class="sr-only">Carregando...</span>
                 </div>
               </div>

--- a/src/app/features/strategic-projects/strategicProjects.component.html
+++ b/src/app/features/strategic-projects/strategicProjects.component.html
@@ -268,89 +268,141 @@
 
       <div class="col-xxl-2 col-md-4 col-sm-6 mb-2 pr-1 pl-1">
         <div class="card">
-          <div class="icon-top-right">
+          <div class="icon-top-right" *ngIf="requestStatus.totals !== 'Loading'">
             <i class="fas fa-cogs"></i>
           </div>
           <div class="card-content">
-            <div class="number-box">{{totals.qdeProgramas}}</div>
+            <ng-container *ngIf="requestStatus.totals === 'Loading' else programasContent">
+              <div class="d-flex justify-content-center align-items-center w-100">
+                <div class="spinner-border text-warning" role="status">
+                  <span class="sr-only">Carregando...</span>
+                </div>
+              </div>
+            </ng-container>
 
-            <div class="text-section">
-              <span>{{totals.qdeProgramas === 1 ? 'Programa' : 'Programas'}}</span>
-            </div>
+            <ng-template #programasContent>
+              <div class="number-box">{{totals.qdeProgramas}}</div>
+
+              <div class="text-section">
+                <span>{{totals.qdeProgramas === 1 ? 'Programa' : 'Programas'}}</span>
+              </div>
+            </ng-template>
           </div>
         </div>
       </div>
 
       <div class="col-xxl-2 col-md-4 col-sm-6 mb-2 pr-1 pl-1">
         <div class="card">
-          <div class="icon-top-right">
+          <div class="icon-top-right" *ngIf="requestStatus.totals !== 'Loading'">
             <i class="fas fa-cog"></i>
           </div>
           <div class="card-content">
-            <div class="number-box">{{totals.qdeProjetos}}</div>
+            <ng-container *ngIf="requestStatus.totals === 'Loading' else projetosContent">
+              <div class="d-flex justify-content-center align-items-center w-100">
+                <div class="spinner-border text-warning" role="status">
+                  <span class="sr-only">Carregando...</span>
+                </div>
+              </div>
+            </ng-container>
 
-            <div class="text-section">
-              <span>{{totals.qdeProjetos === 1 ? 'Projeto' : 'Projetos'}}</span>
-            </div>
+            <ng-template #projetosContent>
+              <div class="number-box">{{totals.qdeProjetos}}</div>
+
+              <div class="text-section">
+                <span>{{totals.qdeProjetos === 1 ? 'Projeto' : 'Projetos'}}</span>
+              </div>
+            </ng-template>
           </div>
         </div>
       </div>
 
       <div class="col-xxl-2 col-md-4 col-sm-6 mb-2 pr-1 pl-1">
         <div class="card">
-          <div class="icon-top-right">
+          <div class="icon-top-right" *ngIf="requestStatus.totals !== 'Loading'">
             <i class="fas fa-cubes"></i>
           </div>
           <div class="card-content">
-            <div class="number-box">{{totals.totalEntregasPE}}</div>
+            <ng-container *ngIf="requestStatus.totals === 'Loading' else entregasContent">
+              <div class="d-flex justify-content-center align-items-center w-100">
+                <div class="spinner-border text-warning" role="status">
+                  <span class="sr-only">Carregando...</span>
+                </div>
+              </div>
+            </ng-container>
 
-            <div class="text-section">
-              <span>{{totals.totalEntregasPE === 1 ? 'Entrega' : 'Entregas'}}</span>
-            </div>
+            <ng-template #entregasContent>
+              <div class="number-box">{{totals.totalEntregasPE}}</div>
+
+              <div class="text-section">
+                <span>{{totals.totalEntregasPE === 1 ? 'Entrega' : 'Entregas'}}</span>
+              </div>
+            </ng-template>
           </div>
         </div>
       </div>
 
       <div class="col-xxl-2 col-md-4 col-sm-6 mb-2 pr-1 pl-1">
         <div class="card">
-          <div class="icon-top-right previsto">
+          <div class="icon-top-right previsto" *ngIf="requestStatus.totals !== 'Loading'">
             <i class="fas fa-calculator"></i>
           </div>
           <div class="card-content">
-            <div class="number-box previsto">
-              <div
-                class="d-flex"
-                style="flex-direction: column; align-items: start"
-              >
-                <div class="currency">R$</div>
-                <div class="value" [title]="'R$ ' + (totals.totalPrevisto | number:'1.2-2')">{{formatNumber(totals.totalPrevisto)}}</div>
+            <ng-container *ngIf="requestStatus.totals === 'Loading' else previstoContent">
+              <div class="d-flex justify-content-center align-items-center w-100">
+                <div class="spinner-border text-warning" role="status">
+                  <span class="sr-only">Carregando...</span>
+                </div>
               </div>
-            </div>
-            <div class="text-section previsto">
-              <span>Previsto</span>
-            </div>
+            </ng-container>
+
+            <ng-template #previstoContent>
+              <div class="number-box previsto">
+                <div
+                  class="d-flex"
+                  style="flex-direction: column; align-items: start"
+                >
+                  <div class="currency">R$</div>
+                  <div class="value" [title]="'R$ ' + (totals.totalPrevisto | number:'1.2-2')">{{formatNumber(totals.totalPrevisto)}}</div>
+                </div>
+              </div>
+            
+              <div class="text-section previsto">
+                <span>Previsto</span>
+              </div>
+            </ng-template>
           </div>
         </div>
       </div>
 
       <div class="col-xxl-2 col-md-4 col-sm-6 mb-2 pr-1 pl-1">
         <div class="card">
-          <div class="icon-top-right realizado">
+          <div class="icon-top-right realizado" *ngIf="requestStatus.totals !== 'Loading'">
             <i class="fas fa-database"></i>
           </div>
           <div class="card-content">
-            <div class="number-box realizado">
-              <div
-                class="d-flex"
-                style="flex-direction: column; align-items: start"
-              >
-                <div class="currency">R$</div>
-                <div class="value" [title]="'R$ ' + (totals.totalRealizado| number:'1.0-2')">{{formatNumber(totals.totalRealizado)}}</div>
+            <ng-container *ngIf="requestStatus.totals === 'Loading' else realizadoContent">
+              <div class="d-flex justify-content-center align-items-center w-100">
+                <div class="spinner-border text-warning" role="status">
+                  <span class="sr-only">Carregando...</span>
+                </div>
               </div>
-            </div>
-            <div class="text-section realizado">
-              <span>Realizado</span>
-            </div>
+            </ng-container>
+
+            <ng-template #realizadoContent>
+              <div class="number-box realizado">
+                <div
+                  class="d-flex"
+                  style="flex-direction: column; align-items: start"
+                >
+                  <div class="currency">R$</div>
+                  <div class="value" [title]="'R$ ' + (totals.totalRealizado| number:'1.0-2')">{{formatNumber(totals.totalRealizado)}}</div>
+                </div>
+              </div>
+              
+              <div class="text-section realizado">
+                <span>Realizado</span>
+              </div>
+            </ng-template>
           </div>
         </div>
       </div>

--- a/src/app/features/strategic-projects/strategicProjects.component.scss
+++ b/src/app/features/strategic-projects/strategicProjects.component.scss
@@ -194,6 +194,19 @@ button:focus, select:focus, input:focus {
       width: 3rem;
       height: 3rem;
       border-width: 0.35em;
+
+      &.qt-programas,
+      &.qt-projetos,
+      &.total-entregas {
+        color: #005C99 !important;
+      }
+
+      &.total-previsto {
+        color: #487D7A !important;
+      }
+      &.total-realizado {
+        color: #00B26A !important;
+      }
     }
 
     .portfolio-content {

--- a/src/app/features/strategic-projects/strategicProjects.component.scss
+++ b/src/app/features/strategic-projects/strategicProjects.component.scss
@@ -170,6 +170,7 @@ button:focus, select:focus, input:focus {
   padding: 5px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   text-align: center;
+  height: 100%;
 
   .delivery-select {
     min-width: 200px;
@@ -187,6 +188,13 @@ button:focus, select:focus, input:focus {
     gap: 20px;
     width: 100%;
     padding: 5px 0 5px 5px;
+    height: 100%;
+
+    .spinner-border {
+      width: 3rem;
+      height: 3rem;
+      border-width: 0.35em;
+    }
 
     .portfolio-content {
       display: flex;

--- a/src/app/features/strategic-projects/strategicProjects.component.ts
+++ b/src/app/features/strategic-projects/strategicProjects.component.ts
@@ -23,6 +23,13 @@ enum AvailableFilters {
   ACOMPANHADO_POR = 'Acompanhado_Por',
 }
 
+export enum RequestStatus {
+  EMPTY = 'Empty',
+  LOADING = 'Loading',
+  SUCCESS = 'Success',
+  ERROR = 'Error',
+}
+
 @Component({
   selector: 'ngx-strategic-projects',
   templateUrl: './strategicProjects.component.html',
@@ -82,6 +89,10 @@ export class StrategicProjectsComponent {
   projetoList: IIdAndName[] = [];
 
   activeFilters: { key: string; label: string; displayValue: Array<{name: string; fullName?: string; }>; }[] = [];
+
+  requestStatus = {
+    totals: RequestStatus.EMPTY,
+  }
 
   constructor(private strategicProjectsService: StrategicProjectsService, private themeService: NbThemeService) {
     this.loadTimestamp();
@@ -305,14 +316,17 @@ export class StrategicProjectsComponent {
   }
 
   loadTotals() {
+    this.requestStatus.totals = RequestStatus.LOADING;
     const cleanedFilter = this.strategicProjectsService.removeEmptyValues(this.finalFilter);
 
     this.strategicProjectsService.getTotals(cleanedFilter).subscribe(
       (totals: IStrategicProjectTotals) => {
         this.totals = totals;
+        this.requestStatus.totals = RequestStatus.SUCCESS;
       },
       (error) => {
         console.error('Erro ao carregar os totais:', error);
+        this.requestStatus.totals = RequestStatus.ERROR;
       }
     );
   }


### PR DESCRIPTION
Nos Projetos Estratégicos:

- [x] Criado um spinner em cada card/gráfico, o qual é exibido enquanto os dados estiverem sendo carregados.