### PR TITLE
INPL 122 - Drill Down nas Áreas Temáticas, Programas e Projetos

### DIFF
--- a/src/app/@theme/pipes/text-truncate.pipe.ts
+++ b/src/app/@theme/pipes/text-truncate.pipe.ts
@@ -6,7 +6,7 @@ export class TextTruncatePipe implements PipeTransform {
     let finalString = element;
 
     if (element.length > numOfChars) {
-      finalString = `${element.slice(0, numOfChars - 1)}...`;
+      finalString = `${element.slice(0, numOfChars)}...`;
     }
 
     if (customLastChar) {

--- a/src/app/features/strategic-projects/bar-chart-model/barChartModel.component.scss
+++ b/src/app/features/strategic-projects/bar-chart-model/barChartModel.component.scss
@@ -1,4 +1,0 @@
-.echart {
-  height: 100%;
-  width: 100%;
-}

--- a/src/app/features/strategic-projects/bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component.html
+++ b/src/app/features/strategic-projects/bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component.html
@@ -1,0 +1,10 @@
+<div [ngStyle]="{ 'height': height + 'px' }" >
+  <div
+    echarts
+    class="echart"
+    [ngStyle]="{ 'height': height + 'px' }"
+    [options]="chartOptions"
+    (chartInit)="onChartInit($event)"
+  >
+  </div>
+</div>

--- a/src/app/features/strategic-projects/bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component.ts
+++ b/src/app/features/strategic-projects/bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component.ts
@@ -1,14 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { NbThemeService } from '@nebular/theme';
-import { EChartsOption } from 'echarts';
+import { ECharts, EChartsOption } from 'echarts';
 import { NgxEchartsModule } from 'ngx-echarts';
-import { AvailableThemes, getAvailableThemesStyles } from '../../../@theme/theme.module';
+import { AvailableThemes, getAvailableThemesStyles } from '../../../../@theme/theme.module';
 
 @Component({
   selector: 'ngx-horizontal-bar-chart-model',
-  templateUrl: './barChartModel.component.html',
-  styleUrls: ['./barChartModel.component.scss'],
+  templateUrl: './horizontal-bar-chart-model.component.html',
+  styles: ['.echarts { width: 100%; height: 100%; }'],
   standalone: true,
   imports: [NgxEchartsModule, CommonModule],
 })
@@ -21,7 +21,7 @@ export class HorizontalBarChartModelComponent implements OnInit, OnChanges {
 
   chartOptions: EChartsOption;
 
-  echartsInstance: any = null
+  echartsInstance: ECharts = null
 
   currentTheme: AvailableThemes = AvailableThemes.DEFAULT;
 
@@ -73,7 +73,7 @@ export class HorizontalBarChartModelComponent implements OnInit, OnChanges {
     }
   }
 
-  onChartInit(chartInstance: any) {
+  onChartInit(chartInstance: ECharts) {
     this.echartsInstance = chartInstance;
   }
 
@@ -134,6 +134,7 @@ export class HorizontalBarChartModelComponent implements OnInit, OnChanges {
         },
         xAxis: {
           type: 'value',
+          
           axisLabel: {
             color: currentThemeStyles.textPrimaryColor,
             fontSize: 9,
@@ -148,6 +149,7 @@ export class HorizontalBarChartModelComponent implements OnInit, OnChanges {
           axisLabel: {
             color: currentThemeStyles.textPrimaryColor,
             fontSize: 9,
+            
             formatter: function (value: string) {
               const maxLength = 50;
               if (value.length > maxLength) {

--- a/src/app/features/strategic-projects/bar-chart-model/vertical-bar-chart-model/vertical-bar-chart-model.component.html
+++ b/src/app/features/strategic-projects/bar-chart-model/vertical-bar-chart-model/vertical-bar-chart-model.component.html
@@ -1,5 +1,3 @@
 <div  [ngStyle]="{ 'height': height + 'px' }" >
   <div echarts [options]="chartOptions" class="echart" (chartInit)="onChartInit($event)"></div>
 </div>
-
-

--- a/src/app/features/strategic-projects/bar-chart-model/vertical-bar-chart-model/vertical-bar-chart-model.component.ts
+++ b/src/app/features/strategic-projects/bar-chart-model/vertical-bar-chart-model/vertical-bar-chart-model.component.ts
@@ -3,12 +3,12 @@ import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/cor
 import { NbThemeService } from '@nebular/theme';
 import { EChartsOption } from 'echarts';
 import { NgxEchartsModule } from 'ngx-echarts';
-import { AvailableThemes, getAvailableThemesStyles } from '../../../@theme/theme.module';
+import { AvailableThemes, getAvailableThemesStyles } from '../../../../@theme/theme.module';
 
 @Component({
   selector: 'ngx-vertical-bar-chart-model',
-  templateUrl: './barChartModel.component.html',
-  styleUrls: ['./barChartModel.component.scss'],
+  templateUrl: './vertical-bar-chart-model.component.html',
+  styles: [' .echarts { width: 100%; height: 100%; } '],
   standalone: true,
   imports: [NgxEchartsModule, CommonModule],
 })

--- a/src/app/features/strategic-projects/data-chart/accumulated-investment/accumulatedInvestment.component.ts
+++ b/src/app/features/strategic-projects/data-chart/accumulated-investment/accumulatedInvestment.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { VerticalBarChartModelComponent } from '../../bar-chart-model/verticalBarChartModel.component';
+import { VerticalBarChartModelComponent } from '../../bar-chart-model/vertical-bar-chart-model/vertical-bar-chart-model.component';
 import { IStrategicProjectAccumulatedInvestment } from '../../../../core/interfaces/strategic-project.interface';
 import { IStrategicProjectFilterValuesDto } from '../../../../core/interfaces/strategic-project-filter.interface';
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';

--- a/src/app/features/strategic-projects/data-chart/critical-milestones-for-performance/criticalMilestonesForPerformace.component.ts
+++ b/src/app/features/strategic-projects/data-chart/critical-milestones-for-performance/criticalMilestonesForPerformace.component.ts
@@ -53,6 +53,7 @@ export class CriticalMilestonesForPerformanceComponent  implements OnChanges {
 
     this.strategicProjectsService.getCriticalMilestonesForPerformace(cleanedFilter)
       .subscribe((data: IStrategicProjectDeliveries[]) => {
+        this.performanceShow = [];
         this.performanceData = data;
 
         this.performanceData.forEach(performace => {

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-performance/deliveriesByPerformace.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-performance/deliveriesByPerformace.component.ts
@@ -51,6 +51,8 @@ export class DeliveriesByPerformaceComponent implements OnChanges {
 
     this.strategicProjectsService.getDeliveriesByPerformace(cleanedFilter)
       .subscribe((data: IStrategicProjectDeliveries[]) => {
+        this.performanceShow = [];
+
         this.performanceData = data;
 
         this.performanceData.forEach(performace => {

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.html
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.html
@@ -4,6 +4,7 @@
   [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
+  (executeCustomFiltering)="handleCustomFiltering($event)"
 >
   <div class="d-flex p-0" custom-header>
     <span class="text-card mr-2">Entregas por</span>

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { HorizontalBarChartModelComponent } from '../../bar-chart-model/horizontalBarChartModel.component';
+import { HorizontalBarChartModelComponent } from '../../bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component';
 import { IStrategicProjectFilterValuesDto } from '../../../../core/interfaces/strategic-project-filter.interface';
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { IStrategicProjectDeliveriesBySelected } from '../../../../core/interfaces/strategic-project.interface';

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-selected/deliveriesBySelected.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { HorizontalBarChartModelComponent } from '../../bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component';
 import { IStrategicProjectFilterValuesDto } from '../../../../core/interfaces/strategic-project-filter.interface';
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
@@ -6,7 +6,8 @@ import { IStrategicProjectDeliveriesBySelected } from '../../../../core/interfac
 import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } from '../../flip-table-model/flip-table.component';
 import { NbSelectModule } from '@nebular/theme';
 import { ExportDataService } from '../../../../core/service/export-data';
-import { RequestStatus } from '../../strategicProjects.component';
+import { CustomTableFilteringTrigger, RequestStatus } from '../../strategicProjects.component';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'ngx-deliveries-by-selected',
@@ -21,6 +22,13 @@ import { RequestStatus } from '../../strategicProjects.component';
 })
 export class DeliveriesBySelectedComponent implements OnChanges {
   @Input() filter!: IStrategicProjectFilterValuesDto;
+
+  @Input() tableFilteringTrigger: BehaviorSubject<CustomTableFilteringTrigger>;
+  // ↳ Este BehaviorSubject é disparado toda vez que o usuário faz uma filtragem ao clicar em um elemento em uma das tabelas
+  // ↳ Todos os componentes que implementam essa filtragem pela tabela devem escutar esse Subject, afim de que quando
+  //   o usuário filtrar algo em qualquer uma das tabelas, a seleção da entidade seja alterada em todas as outras tabelas
+
+  @Output() newFilter = new EventEmitter<IStrategicProjectFilterValuesDto>();
 
   chartData: any;
 
@@ -44,6 +52,18 @@ export class DeliveriesBySelectedComponent implements OnChanges {
       if (this.deliveriesSelectedOption != undefined) {
         this.loadData(); 
       }
+    }
+
+    if (changes['tableFilteringTrigger'] && this.tableFilteringTrigger) {
+      this.tableFilteringTrigger.subscribe((newFilter) => {
+        if (newFilter && newFilter.source !== 'DeliveriesBy') {
+          if (newFilter.newSelectedEntity === 'Entrega') {
+            this.deliveriesSelectedOption = 'Projeto';
+          } else {
+            this.deliveriesSelectedOption = newFilter.newSelectedEntity;
+          }
+        }
+      });
     }
   }
 
@@ -182,6 +202,7 @@ export class DeliveriesBySelectedComponent implements OnChanges {
         originalPropertyName: 'nome',
         propertyName: 'firstColumn',
         displayName: this.deliveriesSelectedOption,
+        enableEventClick: true,
       },
       data: finalData,
     };
@@ -214,5 +235,46 @@ export class DeliveriesBySelectedComponent implements OnChanges {
       columns,
       `InfoPlan_Entregas_por_${this.deliveriesSelectedOption}.xlsx`,
     );
+  }
+
+  handleCustomFiltering(value: string) {
+    const selectedItem = this.deliveriesData.find((item) => item.nome === value);
+    let newFilter: IStrategicProjectFilterValuesDto;
+
+    switch (this.deliveriesSelectedOption) {
+      case 'Área Temática':
+        newFilter = {
+          ...newFilter,
+          areaId: selectedItem.id.toString(),
+        };
+        this.deliveriesSelectedOption = 'Programa';
+        break;
+      case 'Programa':
+        newFilter = {
+          ...newFilter,
+          programaOriginalId: selectedItem.id,
+        };
+        this.deliveriesSelectedOption = 'Projeto';
+        break;
+      case 'Programas Transversais':
+        newFilter = {
+          ...newFilter,
+          programaTransversalId: selectedItem.id,
+        };
+        this.deliveriesSelectedOption = 'Projeto';
+        break;
+      case 'Projeto':
+        newFilter = {
+          ...newFilter,
+          projetoId: selectedItem.id,
+        };
+        this.deliveriesSelectedOption = 'Projeto';
+        break;      
+      default:
+        console.warn('Opção não reconhecida:', this.deliveriesSelectedOption);
+        break;
+    }
+
+    this.newFilter.emit(newFilter);
   }
 }

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
@@ -52,9 +52,9 @@ export class DeliveriesByStatusComponent implements OnChanges {
 
     this.strategicProjectsService.getDeliveriesByStatus(cleanedFilter)
       .subscribe((data: IStrategicProjectDeliveries[]) => {
-        this.statusData = data;
+        this.chartData = [];
 
-        this.statusData.forEach(status => {
+        data.forEach(status => {
           if (status.statusId !== 0 || status.nomeStatus !== 'null') {
             let sShow = this.statusShow.find((s) => s.nomeStatus == status.nomeStatus);
 
@@ -75,7 +75,7 @@ export class DeliveriesByStatusComponent implements OnChanges {
 
         this.statusShow.sort((a, b) => (a.statusId < b.statusId ? -1 : 1));
 
-        this.chartData = this.statusShow.map(val => <any> {
+        this.chartData = this.statusShow.map(val => <any>{
           value: val.count,
           name: val.nomeStatus
         });
@@ -83,8 +83,9 @@ export class DeliveriesByStatusComponent implements OnChanges {
         this.chartColors = this.statusShow.map(val => val.corStatus);
 
         this.assembleFlipTableContent(data);
-
+        
         this.requestStatus = RequestStatus.SUCCESS;
+        this.statusData = data;
       },
       (error) => {
         console.error('Erro ao carregar os dados das entregas por status:', error);
@@ -93,7 +94,7 @@ export class DeliveriesByStatusComponent implements OnChanges {
     );
   }
 
-  assembleFlipTableContent(rawData: IStrategicProjectDeliveries[], shouldStartExpanded: boolean = false) {
+  async assembleFlipTableContent(rawData: IStrategicProjectDeliveries[], shouldStartExpanded: boolean = false) {
     const tableColumns = [
       // { propertyName: 'nomeArea', displayName: 'Nome da Área' },
       { propertyName: 'nomeStatus', displayName: 'Status' },

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
@@ -94,7 +94,7 @@ export class DeliveriesByStatusComponent implements OnChanges {
     );
   }
 
-  async assembleFlipTableContent(rawData: IStrategicProjectDeliveries[], shouldStartExpanded: boolean = false) {
+  assembleFlipTableContent(rawData: IStrategicProjectDeliveries[], shouldStartExpanded: boolean = false) {
     const tableColumns = [
       // { propertyName: 'nomeArea', displayName: 'Nome da Área' },
       { propertyName: 'nomeStatus', displayName: 'Status' },

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-status/deliveriesByStatus.component.ts
@@ -51,8 +51,8 @@ export class DeliveriesByStatusComponent implements OnChanges {
     this.statusShow = [];
 
     this.strategicProjectsService.getDeliveriesByStatus(cleanedFilter)
-      .subscribe((data: IStrategicProjectDeliveries[]) => {
-        this.chartData = [];
+      .subscribe((data: IStrategicProjectDeliveries[] = []) => {
+        this.statusShow = [];
 
         data.forEach(status => {
           if (status.statusId !== 0 || status.nomeStatus !== 'null') {

--- a/src/app/features/strategic-projects/data-chart/deliveries-by-type/deliveriesByType.component.ts
+++ b/src/app/features/strategic-projects/data-chart/deliveries-by-type/deliveriesByType.component.ts
@@ -51,6 +51,7 @@ export class DeliveriesByTypeComponent implements OnChanges {
 
     this.strategicProjectsService.getDeliveriesByType(cleanedFilter)
       .subscribe((data: IStrategicProjectDeliveries[]) => {
+        this.typeShow = [];
         this.typeData = data;
       
         this.typeData.forEach(type => {

--- a/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.html
+++ b/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.html
@@ -4,6 +4,7 @@
   [loadingStatus]="requestStatus"
   (executeSearch)="handleUserTableSearch($event)"
   (executeDownload)="handleUserTableDownload()"
+  (executeCustomFiltering)="handleCustomFiltering($event)"
 >
   <div class="d-flex p-0" custom-header>
     <span class="text-card mr-2">Investimento por</span>

--- a/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.ts
+++ b/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { HorizontalBarChartModelComponent } from '../../bar-chart-model/horizontalBarChartModel.component';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { HorizontalBarChartModelComponent } from '../../bar-chart-model/horizontal-bar-chart-model/horizontal-bar-chart-model.component';
 import { IStrategicProjectFilterValuesDto } from '../../../../core/interfaces/strategic-project-filter.interface';
 import { StrategicProjectsService } from '../../../../core/service/strategic-projects.service';
 import { IStrategicProjectInvestmentSelected } from '../../../../core/interfaces/strategic-project.interface';
@@ -22,6 +22,8 @@ import { RequestStatus } from '../../strategicProjects.component';
 })
 export class InvestmentBySelectedComponent implements OnChanges {
   @Input() filter!: IStrategicProjectFilterValuesDto;
+
+  @Output() newFilter = new EventEmitter<IStrategicProjectFilterValuesDto>();
 
   flipTableContent: FlipTableContent;
 
@@ -198,6 +200,7 @@ export class InvestmentBySelectedComponent implements OnChanges {
         originalPropertyName: 'nome',
         propertyName: 'firstColumn',
         displayName: this.selectedInvestmentOption,
+        enableEventClick: true,
       },
       data: finalData,
     };
@@ -230,5 +233,63 @@ export class InvestmentBySelectedComponent implements OnChanges {
       columns,
       `InfoPlan_Investimento_por_${this.selectedInvestmentOption}.xlsx`,
     );
+  }
+
+  handleCustomFiltering(value: string) {
+    const selectedItem = this.investmentData.find((item) => item.nome === value);
+    let newFilter: IStrategicProjectFilterValuesDto = {
+      areaId: '',
+      programaOriginalId: -1,
+      programaTransversalId: -1,
+      projetoId: -1,
+      entregaId: -1,
+      orgaoId: -1,
+      localidadeId: -1,
+      dataInicio: -1,
+      dataFim: -1,
+    };
+
+    switch (this.selectedInvestmentOption) {
+      case 'Área Temática':
+        newFilter = {
+          ...newFilter,
+          areaId: selectedItem.id.toString(),
+        };
+        this.selectedInvestmentOption = 'Programa';
+        break;
+      case 'Programa':
+        newFilter = {
+          ...newFilter,
+          programaOriginalId: selectedItem.id,
+        };
+        this.selectedInvestmentOption = 'Projeto';
+        break;
+      case 'Programas Transversais':
+        newFilter = {
+          ...newFilter,
+          programaTransversalId: selectedItem.id,
+        };
+        this.selectedInvestmentOption = 'Projeto';
+        break;
+      case 'Projeto':
+        newFilter = {
+          ...newFilter,
+          projetoId: selectedItem.id,
+        };
+        this.selectedInvestmentOption = 'Entrega';
+        break;
+      case 'Entrega':
+        newFilter = {
+          ...newFilter,
+          entregaId: selectedItem.id,
+        };
+        this.selectedInvestmentOption = 'Entrega';
+        break;
+      default:
+        console.warn('Opção não reconhecida:', this.selectedInvestmentOption);
+        break;
+    }
+
+    this.newFilter.emit(newFilter);
   }
 }

--- a/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.ts
+++ b/src/app/features/strategic-projects/data-chart/investment-by-selected/investmentBySelected.component.ts
@@ -7,7 +7,8 @@ import { FlipTableAlignment, FlipTableComponent, FlipTableContent, TreeNode } fr
 import { NbSelectModule } from '@nebular/theme';
 import { ExportDataService } from '../../../../core/service/export-data';
 import { UtilitiesService } from '../../../../core/service/utilities.service';
-import { RequestStatus } from '../../strategicProjects.component';
+import { CustomTableFilteringTrigger, RequestStatus } from '../../strategicProjects.component';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'ngx-investment-by-selected',
@@ -22,6 +23,11 @@ import { RequestStatus } from '../../strategicProjects.component';
 })
 export class InvestmentBySelectedComponent implements OnChanges {
   @Input() filter!: IStrategicProjectFilterValuesDto;
+
+  @Input() tableFilteringTrigger: BehaviorSubject<CustomTableFilteringTrigger>;
+  // ↳ Este BehaviorSubject é disparado toda vez que o usuário faz uma filtragem ao clicar em um elemento em uma das tabelas
+  // ↳ Todos os componentes que implementam essa filtragem pela tabela devem escutar esse Subject, afim de que quando
+  //   o usuário filtrar algo em qualquer uma das tabelas, a seleção da entidade seja alterada em todas as outras tabelas
 
   @Output() newFilter = new EventEmitter<IStrategicProjectFilterValuesDto>();
 
@@ -46,8 +52,16 @@ export class InvestmentBySelectedComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if ((changes['filter'] && this.filter)) {
       if (this.selectedInvestmentOption != undefined) {
-        this.loadData(); 
+        this.loadData();
       }
+    }
+
+    if (changes['tableFilteringTrigger'] && this.tableFilteringTrigger) {
+      this.tableFilteringTrigger.subscribe((newFilter) => {
+        if (newFilter && newFilter.source !== 'InvestmentBy') {
+          this.selectedInvestmentOption = newFilter.newSelectedEntity;
+        }
+      });
     }
   }
 
@@ -237,17 +251,7 @@ export class InvestmentBySelectedComponent implements OnChanges {
 
   handleCustomFiltering(value: string) {
     const selectedItem = this.investmentData.find((item) => item.nome === value);
-    let newFilter: IStrategicProjectFilterValuesDto = {
-      areaId: '',
-      programaOriginalId: -1,
-      programaTransversalId: -1,
-      projetoId: -1,
-      entregaId: -1,
-      orgaoId: -1,
-      localidadeId: -1,
-      dataInicio: -1,
-      dataFim: -1,
-    };
+    let newFilter: IStrategicProjectFilterValuesDto;
 
     switch (this.selectedInvestmentOption) {
       case 'Área Temática':

--- a/src/app/features/strategic-projects/data-chart/projects-by-status/projectsByStatus.component.ts
+++ b/src/app/features/strategic-projects/data-chart/projects-by-status/projectsByStatus.component.ts
@@ -51,6 +51,7 @@ export class ProjectsByStatusComponent implements OnChanges {
 
     this.strategicProjectsService.getProjectByStatus(cleanedFilter)
       .subscribe((data: IStrategicProjectDeliveries[]) => {
+        this.statusShow = [];
         this.statusData = data;
 
         this.statusData.forEach(status => {

--- a/src/app/features/strategic-projects/data-chart/risks-by-classification/risksByClassification.component.ts
+++ b/src/app/features/strategic-projects/data-chart/risks-by-classification/risksByClassification.component.ts
@@ -51,6 +51,7 @@ export class RisksByClassificationComponent implements OnChanges {
 
     this.strategicProjectsService.getRisksByClassification(cleanedFilter)
       .subscribe((data: IStrategicProjectRisksByClassification[]) => {
+        this.riskShow = [];
         this.riskData = data;
 
         this.riskData.forEach(risk => {

--- a/src/app/features/strategic-projects/flip-table-model/flip-table.component.html
+++ b/src/app/features/strategic-projects/flip-table-model/flip-table.component.html
@@ -91,8 +91,9 @@
                 nbTooltipPlacement="right"
                 nbTooltipStatus="basic"
                 [nbTooltip]="getCellValue(row.data, tableContent.customColumn.propertyName)"
-                [ngClass]="{ 'cursor-pointer': row.children }"
+                [ngClass]="{ 'cursor-pointer': row.children || tableContent.customColumn.enableEventClick }"
                 [style]="{ 'text-align': tableContent.customColumn.alignment?.data || 'left' }"
+                (click)="tableContent.customColumn.enableEventClick ? handleCustomColumnClick(row.data[0].value) : ''"
               >
                 <div class="d-flex align-items-center text-truncate" [ngClass]="{ 'pl-2': !row.children }">
                   <ng-container *ngIf="row.children">

--- a/src/app/features/strategic-projects/flip-table-model/flip-table.component.scss
+++ b/src/app/features/strategic-projects/flip-table-model/flip-table.component.scss
@@ -106,7 +106,9 @@
         td {
           font-size: 10px !important;
           line-height: 125%;
-          padding: 0;
+          padding-top: 0;
+          padding-bottom: 0;
+          padding-left: .5em;
           height: 25px;
         }
 

--- a/src/app/features/strategic-projects/flip-table-model/flip-table.component.ts
+++ b/src/app/features/strategic-projects/flip-table-model/flip-table.component.ts
@@ -28,6 +28,7 @@ interface FlipTableColumn {
     header: FlipTableAlignment;
     data: FlipTableAlignment;
   };
+  enableEventClick?: boolean;
 }
 
 export interface FlipTableContent {
@@ -70,6 +71,8 @@ export class FlipTableComponent implements OnChanges {
   @Output() executeSearch = new EventEmitter<string>();
 
   @Output() executeDownload = new EventEmitter<any>();
+
+  @Output() executeCustomFiltering = new EventEmitter<string>();
   
   isFlipCardFlipped: boolean = false;
 
@@ -151,6 +154,10 @@ export class FlipTableComponent implements OnChanges {
   handleSortClick(sortRequest: NbSortRequest): void {
     this.sortColumn = sortRequest.column;
     this.sortDirection = sortRequest.direction;
+  }
+
+  handleCustomColumnClick(value: string) {
+    this.executeCustomFiltering.emit(value);
   }
 
   /* Getters */

--- a/src/app/features/strategic-projects/pie-chart-model/pieChartModel.component.ts
+++ b/src/app/features/strategic-projects/pie-chart-model/pieChartModel.component.ts
@@ -78,7 +78,7 @@ export class PieChartModelComponent implements OnInit, OnChanges {
     this.currentTheme = (this.themeService.currentTheme as AvailableThemes);
   }
 
-  async ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges) {
     if (changes['data']) {
       this.initChartOptions(this.data, this.colors);
     }
@@ -130,12 +130,6 @@ export class PieChartModelComponent implements OnInit, OnChanges {
       : this.centerX - 1;
 
     const currentThemeStyles = getAvailableThemesStyles(this.currentTheme);
-
-    // this.echartsInstance.clear();
-
-    if (data?.some((el) => el.name === 'Em planejamento')) {
-      console.log('data: ', data.map((el) => `name: ${el.name}, value: ${el.value}`));
-    }
 
     this.chartOptions = {
       tooltip: {

--- a/src/app/features/strategic-projects/pie-chart-model/pieChartModel.component.ts
+++ b/src/app/features/strategic-projects/pie-chart-model/pieChartModel.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, HostListener, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { NbThemeService } from '@nebular/theme';
-import { EChartsOption } from 'echarts';
+import { ECharts, EChartsOption } from 'echarts';
 import { NgxEchartsModule } from 'ngx-echarts';
 import { AvailableThemes, getAvailableThemesStyles } from '../../../@theme/theme.module';
 
@@ -26,7 +26,7 @@ export class PieChartModelComponent implements OnInit, OnChanges {
 
   chartOptions: EChartsOption;
 
-  echartsInstance: any = null
+  echartsInstance: ECharts = null
 
   centerX: number = 70;
 
@@ -78,13 +78,13 @@ export class PieChartModelComponent implements OnInit, OnChanges {
     this.currentTheme = (this.themeService.currentTheme as AvailableThemes);
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['data'] || changes['colors']) {
+  async ngOnChanges(changes: SimpleChanges) {
+    if (changes['data']) {
       this.initChartOptions(this.data, this.colors);
     }
   }
 
-  onChartInit(chartInstance: any) {
+  onChartInit(chartInstance: ECharts) {
     this.echartsInstance = chartInstance;
 
     chartInstance.on('legendselectchanged', (params: any) => {
@@ -130,6 +130,12 @@ export class PieChartModelComponent implements OnInit, OnChanges {
       : this.centerX - 1;
 
     const currentThemeStyles = getAvailableThemesStyles(this.currentTheme);
+
+    // this.echartsInstance.clear();
+
+    if (data?.some((el) => el.name === 'Em planejamento')) {
+      console.log('data: ', data.map((el) => `name: ${el.name}, value: ${el.value}`));
+    }
 
     this.chartOptions = {
       tooltip: {
@@ -203,7 +209,7 @@ export class PieChartModelComponent implements OnInit, OnChanges {
             fontSize: 9,
           },
           labelLine: { show: false },
-        }
+        },
       ],
       color: colors || [],
     };

--- a/src/app/features/strategic-projects/strategicProjects.component.html
+++ b/src/app/features/strategic-projects/strategicProjects.component.html
@@ -11,7 +11,7 @@
 
               <div class="tag-value">
                 <ng-container *ngFor="let value of tag.displayValue; let index = index">
-                  <ng-container *ngIf="value.name?.length <= 17 else spanWithTooltip">
+                  <ng-container *ngIf="value.name?.length <= 20 else spanWithTooltip">
                     <span>
                       {{ (index > 0 ? ' ' : '') + (tag.displayValue.length > 1 ?  (value.name | TextTruncate : 17 : ';') : value.name) }}
                     </span>

--- a/src/app/features/strategic-projects/strategicProjects.component.html
+++ b/src/app/features/strategic-projects/strategicProjects.component.html
@@ -446,7 +446,7 @@
      
     <div [ngClass]="{'col-xxxl-12': isMapOpen, 'col-xxxl-6': !isMapOpen}" class="col-md-12 pr-0 pl-0 d-flex flex-wrap">
       <div [ngClass]="{'col-xxxl-6': isMapOpen, 'col-xxxl-12': !isMapOpen}" class="col-xxl-6 col-12 pr-1 pl-1 mb-2 ">
-        <ngx-investment-by-selected [filter]="finalFilter"></ngx-investment-by-selected>
+        <ngx-investment-by-selected [filter]="finalFilter" (newFilter)="handleNewFilter($event)"></ngx-investment-by-selected>
       </div>
 
       <div [ngClass]="{'col-xxxl-6': isMapOpen, 'col-xxxl-12': !isMapOpen}" class="col-xxl-6 col-12 pr-1 pl-1 mb-2">

--- a/src/app/features/strategic-projects/strategicProjects.component.html
+++ b/src/app/features/strategic-projects/strategicProjects.component.html
@@ -446,11 +446,21 @@
      
     <div [ngClass]="{'col-xxxl-12': isMapOpen, 'col-xxxl-6': !isMapOpen}" class="col-md-12 pr-0 pl-0 d-flex flex-wrap">
       <div [ngClass]="{'col-xxxl-6': isMapOpen, 'col-xxxl-12': !isMapOpen}" class="col-xxl-6 col-12 pr-1 pl-1 mb-2 ">
-        <ngx-investment-by-selected [filter]="finalFilter" (newFilter)="handleNewFilter($event)"></ngx-investment-by-selected>
+        <ngx-investment-by-selected
+          [filter]="finalFilter"
+          [tableFilteringTrigger]="tableFilteringTrigger"
+          (newFilter)="handleNewTableFilter($event, 'InvestmentBy')"
+        >
+        </ngx-investment-by-selected>
       </div>
 
       <div [ngClass]="{'col-xxxl-6': isMapOpen, 'col-xxxl-12': !isMapOpen}" class="col-xxl-6 col-12 pr-1 pl-1 mb-2">
-        <ngx-deliveries-by-selected [filter]="finalFilter"></ngx-deliveries-by-selected>
+        <ngx-deliveries-by-selected
+          [filter]="finalFilter"
+          [tableFilteringTrigger]="tableFilteringTrigger"
+          (newFilter)="handleNewTableFilter($event, 'DeliveriesBy')"
+        >
+        </ngx-deliveries-by-selected>
       </div>
     </div>
 

--- a/src/app/features/strategic-projects/strategicProjects.component.ts
+++ b/src/app/features/strategic-projects/strategicProjects.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { environment } from '../../../environments/environment';
 import { StrategicProjectsService } from '../../core/service/strategic-projects.service';
 import { IIdAndName } from '../../core/interfaces/id-and-name.interface';
-import { IStrategicProjectFilterDataDto } from '../../core/interfaces/strategic-project-filter.interface';
+import { IStrategicProjectFilterDataDto, IStrategicProjectFilterValuesDto } from '../../core/interfaces/strategic-project-filter.interface';
 import { IStrategicProjectTotals } from '../../core/interfaces/strategic-project-totals.interface';
 import { IStrategicProjectTimestamp } from '../../core/interfaces/strategic-project.interface';
 import { NbThemeService } from '@nebular/theme';
@@ -255,9 +255,9 @@ export class StrategicProjectsComponent {
     this.showFilters = !this.showFilters;
   }
 
-  filtrar(event: Event): void {
-    event.preventDefault();
-    this.showFilters = !this.showFilters;
+  filtrar(event?: Event): void {
+    if (event) event.preventDefault();
+    this.showFilters = false;
     this.finalFilter = { ...this.filter };
     this.updateActiveFilters();
     this.loadTotals()
@@ -362,5 +362,23 @@ export class StrategicProjectsComponent {
     this.updateActiveFilters();
 
     this.loadTotals();
+  }
+
+  handleNewFilter(newFilter: IStrategicProjectFilterValuesDto) {
+    let newLocalFilter: any = {
+      portfolio: environment.strategicProjectFilter.portfolio,
+      dataInicio: new Date(environment.strategicProjectFilter.dataInicio),
+      dataFim: new Date(environment.strategicProjectFilter.dataFim),
+      previsaoConclusao: '',
+    };
+
+    if (newFilter.areaId) newLocalFilter.areaTematica = [Number(newFilter.areaId)];
+    if (newFilter.programaOriginalId) newLocalFilter.programaOrigem = [newFilter.programaOriginalId];
+    if (newFilter.programaTransversalId) newLocalFilter.programaTransversal = [newFilter.programaTransversalId];
+    if (newFilter.projetoId) newLocalFilter.projetos = [newFilter.projetoId];
+    if (newFilter.entregaId) newLocalFilter.entregas = [newFilter.entregaId];
+
+    this.filter = newLocalFilter;
+    this.filtrar();
   }
 }

--- a/src/app/features/strategic-projects/strategicProjects.component.ts
+++ b/src/app/features/strategic-projects/strategicProjects.component.ts
@@ -7,6 +7,7 @@ import { IStrategicProjectTotals } from '../../core/interfaces/strategic-project
 import { IStrategicProjectTimestamp } from '../../core/interfaces/strategic-project.interface';
 import { NbThemeService } from '@nebular/theme';
 import { AvailableThemes } from '../../@theme/theme.module';
+import { BehaviorSubject } from 'rxjs';
 
 enum AvailableFilters {
   PORTFOLIO = 'Portfolio',
@@ -28,6 +29,11 @@ export enum RequestStatus {
   LOADING = 'Loading',
   SUCCESS = 'Success',
   ERROR = 'Error',
+}
+
+export interface CustomTableFilteringTrigger {
+  source: 'InvestmentBy' | 'DeliveriesBy';
+  newSelectedEntity: 'Área Temática' | 'Programa' | 'Programas Transversais' | 'Projeto' | 'Entrega';
 }
 
 @Component({
@@ -93,6 +99,8 @@ export class StrategicProjectsComponent {
   requestStatus = {
     totals: RequestStatus.EMPTY,
   }
+
+  tableFilteringTrigger = new BehaviorSubject<CustomTableFilteringTrigger>(null);
 
   constructor(private strategicProjectsService: StrategicProjectsService, private themeService: NbThemeService) {
     this.loadTimestamp();
@@ -364,21 +372,42 @@ export class StrategicProjectsComponent {
     this.loadTotals();
   }
 
-  handleNewFilter(newFilter: IStrategicProjectFilterValuesDto) {
+  handleNewTableFilter(newFilter: IStrategicProjectFilterValuesDto, source: 'InvestmentBy' | 'DeliveriesBy') {
     let newLocalFilter: any = {
       portfolio: environment.strategicProjectFilter.portfolio,
       dataInicio: new Date(environment.strategicProjectFilter.dataInicio),
       dataFim: new Date(environment.strategicProjectFilter.dataFim),
-      previsaoConclusao: '',
     };
 
-    if (newFilter.areaId) newLocalFilter.areaTematica = [Number(newFilter.areaId)];
-    if (newFilter.programaOriginalId) newLocalFilter.programaOrigem = [newFilter.programaOriginalId];
-    if (newFilter.programaTransversalId) newLocalFilter.programaTransversal = [newFilter.programaTransversalId];
-    if (newFilter.projetoId) newLocalFilter.projetos = [newFilter.projetoId];
-    if (newFilter.entregaId) newLocalFilter.entregas = [newFilter.entregaId];
+    let newEntityToBeDisplayed;
+
+    if (newFilter.areaId) {
+      newLocalFilter = { ...newLocalFilter, areaTematica: [Number(newFilter.areaId)] }; 
+      newEntityToBeDisplayed = 'Programa';
+    }
+    if (newFilter.programaOriginalId) {
+      newLocalFilter = { ...newLocalFilter, programaOrigem: [newFilter.programaOriginalId] };
+      newEntityToBeDisplayed = 'Projeto';
+    }
+    if (newFilter.programaTransversalId) {
+      newLocalFilter = { ...newLocalFilter, programaTransversal: [newFilter.programaTransversalId] };
+      newEntityToBeDisplayed = 'Projeto';
+    }
+    if (newFilter.projetoId) {
+      newLocalFilter = { ...newLocalFilter, projetos: [newFilter.projetoId] };
+      newEntityToBeDisplayed = 'Entrega';
+    }
+    if (newFilter.entregaId) {
+      newLocalFilter = { ...newLocalFilter, entregas: [newFilter.entregaId] };
+      newEntityToBeDisplayed = 'Entrega';
+    }
 
     this.filter = newLocalFilter;
     this.filtrar();
+
+    this.tableFilteringTrigger.next({
+      source,
+      newSelectedEntity: newEntityToBeDisplayed,
+    });
   }
 }


### PR DESCRIPTION
Nos Projetos Estratégicos:

- [x] Criado um esquema que permite exibir o cursor como "pointer" em uma certa coluna do FlipTable, e um evento é disparado ao selecionar um item;
- [x] Implementado uma filtragem ao selecionar um item nas tabelas dos gráficos "Investimento por" e "Entregas por".
Ao selecionar um item (por ex., uma Área Temática), a seleção das tabelas é alterada para exibir os elementos filhos da entidade selecionada (se selecionou uma Área Temática, será listado os Programas da Área selecionada. Se selecionou um Programa, será listado os Projetos do Programa selecionado... etc).

Extras:

- [x] Corrigido um bug que ocorria ao selecionar rapidamente vários municípios seguidos no Mapa. A ContagemPE final sendo exibida nos gráficos às vezes bugava, exibindo um valor muito maior do que o real. A correção foi aplicada para todos os gráficos.
- [x] Corrigido um pequeno erro na formatação dos nomes das entidades nos chips de filtros.