### PR TITLE
INPL 132 - Ordenação dos Filtros de Localidades na Tela de Projetos Estratégicos

### DIFF
--- a/src/app/core/interfaces/id-and-name.interface.ts
+++ b/src/app/core/interfaces/id-and-name.interface.ts
@@ -1,6 +1,10 @@
 export interface IIdAndName {
-    id: number;
-    name: string;
-    fullName?: string;
+  id: number;
+  name: string;
+  fullName?: string;
 }
 
+export interface StrategicProjectsLocalidades extends IIdAndName {
+  tipo: 'ESTADO' |  'MICRORREGIÃO' | 'MUNICÍPIO';
+  microregiaoId?: number;
+}

--- a/src/app/core/interfaces/strategic-project-filter.interface.ts
+++ b/src/app/core/interfaces/strategic-project-filter.interface.ts
@@ -1,4 +1,4 @@
-import { IIdAndName } from "./id-and-name.interface";
+import { IIdAndName, StrategicProjectsLocalidades } from "./id-and-name.interface";
 
 export interface IStrategicProjectFilterDataDto {
   area: IIdAndName[];
@@ -7,7 +7,7 @@ export interface IStrategicProjectFilterDataDto {
   projetos: IIdAndName[];
   entregas: IIdAndName[];
   orgaos: IIdAndName[];
-  localidades: IIdAndName[];
+  localidades: StrategicProjectsLocalidades[];
 }
 
 export interface IStrategicProjectFilterValuesDto {

--- a/src/app/features/strategic-projects/strategicProjects.component.html
+++ b/src/app/features/strategic-projects/strategicProjects.component.html
@@ -206,7 +206,11 @@
                 size="tiny"
                 [(ngModel)]="filter.localidades"
               >
-                <nb-option *ngFor="let localidade of localidadeList" [value]="localidade.id">
+                <nb-option
+                  *ngFor="let localidade of localidadeList"
+                  [value]="localidade.id"
+                  [ngClass]="{ 'pl-4': localidade.tipo === 'MUNICÍPIO' }"
+                >
                   {{ localidade.name }}
                 </nb-option>
               </nb-select>

--- a/src/app/features/strategic-projects/strategicProjects.component.ts
+++ b/src/app/features/strategic-projects/strategicProjects.component.ts
@@ -281,8 +281,26 @@ export class StrategicProjectsComponent {
         ];
         this.programaTList = allFilterList.programasTransversal;
         this.entregaList = allFilterList.entregas;
-        this.orgaoList = allFilterList.orgaos;
-        this.localidadeList = allFilterList.localidades;
+        this.orgaoList = allFilterList.orgaos.sort((a, b) => a.name.localeCompare(b.name));
+        
+        // Monta a lista de localidades, ordenando por ordem alfabética todas as microregiões, e os municípios que pertencem àquela microregião
+
+        const localidadesList = [allFilterList.localidades.find((el) => el.tipo === 'ESTADO')];
+        
+        const microregioes = allFilterList.localidades
+          .filter((localidade) => localidade?.tipo === 'MICRORREGIÃO')
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        microregioes.forEach((regiao) => {
+          localidadesList.push(regiao);
+
+          allFilterList.localidades
+          .filter((localidade) => localidade?.microregiaoId === regiao.microregiaoId && localidade?.name !== regiao.name)
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .forEach((localidade) => localidadesList.push(localidade));
+        });
+
+        this.localidadeList = localidadesList;
         this.projetoList = allFilterList.projetos;
       },
       (error) => {


### PR DESCRIPTION
Na tela de Projetos Estratégicos:

- [x] Inserido uma lógica na listagem de Localidades nos Filtros para que siga a seguinte lógica:
- - Em primeiro lugar, aparece a opção "Todo o Estado";
- - As Localidades do tipo "Microregião" são listadas por ordem alfabética;
- - Logo abaixo de cada Microregião são listados os municípios que a compõem, também em ordem alfabética;
- - Todos os municípios possuem uma pequena identação à direita, para deixar visualmente claro que esses itens são "internos" à Microregião listada acima deles.
- [x] A listagem de órgãos também passa a ser por ordem alfabética.